### PR TITLE
Add control over spherical harmonics expansion degree

### DIFF
--- a/src/ppigrf/ppigrf.py
+++ b/src/ppigrf/ppigrf.py
@@ -554,7 +554,7 @@ def igrf_gc(r, theta, phi, date, coeff_fn = shc_fn, lower=1, upper=13):
     return Br.reshape(outshape), Btheta.reshape(outshape), Bphi.reshape(outshape)
 
 
-def igrf(lon, lat, h, date, coeff_fn = shc_fn):
+def igrf(lon, lat, h, date, coeff_fn = shc_fn, lower=1, upper=13):
     """
     Calculate IGRF model components
 
@@ -579,6 +579,10 @@ def igrf(lon, lat, h, date, coeff_fn = shc_fn):
         one or more dates to evaluate IGRF coefficients
     coeff_fn : string, optional
         filename of .shc file. Default is latest IGRF
+    lower : int, optional
+        lowest degree of expansion, lower >= 1
+    upper : int, optional
+        highest degree of expansion, 1 <= upper <= 13
 
     Return
     ------
@@ -592,6 +596,11 @@ def igrf(lon, lat, h, date, coeff_fn = shc_fn):
         ellipsoid
     """
 
+    if lower > upper:
+        print('Warning: Highest degree of expansion must be larger or equal to lowest degree.')
+        print('Reset to original range.')
+        lower, upper = 1, 13
+    
     # convert input to arrays and cast to same shape:
     lon, lat, h = np.broadcast_arrays(lon, lat, h)
     shape = lon.shape
@@ -602,7 +611,7 @@ def igrf(lon, lat, h, date, coeff_fn = shc_fn):
     phi = lon
 
     # calculate geocentric components of IGRF:
-    Br, Btheta, Bphi = igrf_gc(r, theta, phi, date, coeff_fn = coeff_fn)
+    Br, Btheta, Bphi = igrf_gc(r, theta, phi, date, coeff_fn = coeff_fn, lower=lower, upper=upper)
     Be = Bphi
 
     # convert output to geodetic


### PR DESCRIPTION
# Purpose
This pull request introduces enhancements to three functions `igrf`, `igrf_gc`, and `igrf_V` within the repository. These changes provide users with greater control over the spherical harmonics expansion by allowing them to specify the minimum and maximum degree of the expansion.

# Key Changes
## New Arguments:

- Added two new optional arguments (`min_degree` and `max_degree`) to the modified functions.
- These arguments enable users to compute:
   - The pure dipole field by setting `min_degree=1` and `max_degree=1`.
   - The multi-pole contribution by adjusting these parameters to desired values.


## Improved Flexibility:

Users can now isolate specific contributions to the global magnetic field of the Earth.

## Backward Compatibility:

Default values ensure that the original behavior of the functions is preserved when the new arguments are not provided.

# Testing Instructions

Pull this branch and install the updated package.

Test the modified functions with various `min_degree` and `max_degree` combinations:

- **Example 1**: `min_degree=1, max_degree=1`(pure dipole field).
- **Example 2**: `min_degree=2, max_degree=13` (multi-pole contributions).
- **Example 3**: Default behavior (no arguments).

Verify that results match expectations for the original behavior when no new arguments are provided.

Please provide feedback or suggest further refinements if needed.